### PR TITLE
docs: add encoding configuration examples

### DIFF
--- a/website/cue/reference/components/sinks.cue
+++ b/website/cue/reference/components/sinks.cue
@@ -172,6 +172,7 @@ components: sinks: [Name=string]: {
 					description: "Configures the encoding specific sink behavior."
 					required:    features.send.encoding.codec.enabled
 					if !features.send.encoding.codec.enabled {common: true}
+					type: object: examples: [{codec: "text"}]
 					type: object: options: {
 						if features.send.encoding.codec.enabled {
 							codec: {

--- a/website/scripts/create-config-examples.js
+++ b/website/scripts/create-config-examples.js
@@ -65,6 +65,8 @@ const getExampleValue = (param, deepFilter) => {
             }
           }
         });
+      } else {
+        value = getValue(p);
       }
     } else {
       value = getValue(p);


### PR DESCRIPTION
Signed-off-by: Cuichen Li <cuichli@cisco.com>

<!--
**Your PR title must conform to the conventional commit spec!**

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/semantic.yml#L20
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->

This PR tries to show the encoding configurations examples in the examples block.

I am new to the vector project and was trying the `aws_s3` sink, I followed the example configurations and then got error says `encoding` was not specified. So I raised this PR. Honestly I am not sure if the change is in the right way and if it will break anywhere else. Feel free to reject the PR. Thanks! 